### PR TITLE
add LC_ALL=C to environment

### DIFF
--- a/pynmcli/cli.py
+++ b/pynmcli/cli.py
@@ -13,12 +13,12 @@ def execute_shell(command):
     return execute(command, wait=True, shellexec=True, errorstring='CLI Error')
 
 
-def execute(command='', errorstring='', wait=True, shellexec=False, ags=None):
+def execute(command='', errorstring='', wait=True, shellexec=False, ags=None, env={'LC_ALL' : 'C'}):
     try:
         if (shellexec):
-            p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
         else:
-            p = subprocess.Popen(args=ags)
+            p = subprocess.Popen(args=ags, env=env)
 
         if wait:
             p.wait()


### PR DESCRIPTION
I just noticed that unified interpreting nmcli's data on multiple hosts can be problematic when they use non-english locales, as nmcli always uses localized output.

To fix this issue, I suggest adding the LC_ALL=C environment variable to the subprocess.Popen() command in cli.py (see [nmcli documentation on developer.gnome.org](https://developer.gnome.org/NetworkManager/stable/nmcli.html#internationalization_notes) )